### PR TITLE
Fix `panic: unaligned 64-bit atomic operation` in 32-bit mode.

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -19,8 +19,8 @@ import (
 )
 
 type Pool struct {
-	backends map[string]*Backend
 	current  uint64
+	backends map[string]*Backend
 	lock     sync.Mutex
 }
 


### PR DESCRIPTION
On my Raspberry Pi for 32-bit mode, it will raise panic
```
panic: unaligned 64-bit atomic operation

goroutine 49 [running]:
runtime/internal/atomic.panicUnaligned()
        /usr/local/go1.22.2.linux-armv6l/src/runtime/internal/atomic/unaligned.go:8 +0x24
runtime/internal/atomic.Xadd64(0x15491bc, 0x1)
        /usr/local/go1.22.2.linux-armv6l/src/runtime/internal/atomic/atomic_arm.s:265 +0x14
github.com/mingcheng/socks5lb.(*Pool).NextIndex(...)
        /home/pi/socks5lb/pool.go:72
github.com/mingcheng/socks5lb.(*Pool).Next(0x15491b8)
        /home/pi/socks5lb/pool.go:89 +0x1a0
github.com/mingcheng/socks5lb.(*Server).ListenSocks5.func1()
        /home/pi/socks5lb/socks5.go:38 +0x80
created by github.com/mingcheng/socks5lb.(*Server).ListenSocks5 in goroutine 21
        /home/pi/socks5lb/socks5.go:35 +0x150
```

To ensure 64 bit alignment, the order of one member definition was moved.
The final 32-bit executable file was passed on my Raspberry Pi system.